### PR TITLE
Version updates

### DIFF
--- a/hidemyass.gemspec
+++ b/hidemyass.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = HideMyAss::VERSION
 
-  gem.add_dependency "nokogiri", "~> 1.5.6"
-  gem.add_dependency "typhoeus", "~> 0.6.1"
-  gem.add_development_dependency "rspec", "~> 2.13.0"
+  gem.add_dependency "nokogiri", ">= 1.5.6"
+  gem.add_dependency "typhoeus", ">= 0.6.1"
+  gem.add_development_dependency "rspec", ">= 2.13.0"
 end

--- a/spec/lib/hidemyass/request_spec.rb
+++ b/spec/lib/hidemyass/request_spec.rb
@@ -3,8 +3,8 @@ require "spec_helper"
 describe HideMyAss::Request do
 
   let(:url)     { "127.0.0.1" }
-  let(:res)     { stub(on_complete: nil).as_null_object }
-  let(:hydra)   { stub.as_null_object }
+  let(:res)     { double(on_complete: nil).as_null_object }
+  let(:hydra)   { double.as_null_object }
   let(:proxies) { [{host: "1.2.3.4", port: "80"}] }
   let(:proxy)   { "http://#{proxies[0][:host]}:#{proxies[0][:port]}" }
 


### PR DESCRIPTION
Update the allowed versions of Nokogiri, Typhoeus, and RSpec to be more flexible and allow recent versions.  Fix deprecation warnings.
