### PR TITLE
Only mark GET requests as successful if the return code is ok

### DIFF
--- a/lib/hidemyass/request/operations.rb
+++ b/lib/hidemyass/request/operations.rb
@@ -19,10 +19,12 @@ module HideMyAss
           # Pass request to Typhoeus
           request = Typhoeus::Request.new(base_url, options)
           request.on_complete do |response|
-            HideMyAss.log "#{request.options[:proxy]} : #{response.code}"
+            HideMyAss.log "#{request.options[:proxy]} : #{response.code} #{response.return_code}"
+            has_success_response_code = (200..300).member?(response.code)
+            is_aborted_get = (response.code == 200) && (response.return_code.try(:to_s) != 'ok')
 
             # Return on successful http code
-            if (200..300).member?(response.code)
+            if has_success_response_code && !is_aborted_get
               @response = response and HideMyAss.hydra.abort
             end
           end


### PR DESCRIPTION
We were seeing cases where the Typhoeus request would return a status code of 200, but the return code indicated a problem had occurred (typically a timeout).  In this case the response body was incomplete, which means the response should have been treated as a failure for our purposes.

We made minor changes to the response logic to test for this scenario.   We are running with this change in production and not seeing any issues.  It resolved the observed problem.
