### PR TITLE
Convert specs to RSpec 3.0.0 syntax with Transpec

### DIFF
--- a/spec/lib/hidemyass/request_spec.rb
+++ b/spec/lib/hidemyass/request_spec.rb
@@ -9,14 +9,14 @@ describe HideMyAss::Request do
   let(:proxy)   { "http://#{proxies[0][:host]}:#{proxies[0][:port]}" }
 
   before do
-    HideMyAss.stub(:hydra).and_return(hydra)
-    HideMyAss.stub(:proxies).and_return(proxies)
+    allow(HideMyAss).to receive(:hydra).and_return(hydra)
+    allow(HideMyAss).to receive(:proxies).and_return(proxies)
   end
 
   [:get, :post, :put, :delete].each do |http_method|
     describe ".#{http_method}" do
       it "passes :#{http_method} message to typhoeus" do
-        Typhoeus::Request.should_receive(:new).
+        expect(Typhoeus::Request).to receive(:new).
           with(url, { :method => http_method }.merge(proxy: proxy)).
           and_return(res)
 


### PR DESCRIPTION
This conversion is done by Transpec 2.2.4 with the following command:
    transpec
- 2 conversions
  from: obj.stub(:message)
    to: allow(obj).to receive(:message)
- 1 conversion
  from: obj.should_receive(:message)
    to: expect(obj).to receive(:message)

For more details: https://github.com/yujinakayama/transpec#supported-conversions
